### PR TITLE
Display vector element values as both integer and DP FP

### DIFF
--- a/gdb/features/ve-core.xml
+++ b/gdb/features/ve-core.xml
@@ -124,7 +124,9 @@
   <reg name="vm15" bitsize="256" type="v4u64"/>
 
   <vector id="v256d" type="ieee_double" count="256"/>
+  <vector id="v256l" type="uint64" count="256"/>
   <union id="vec64">
+    <field name="v256_uint64" type="v256l"/>
     <field name="v256_double" type="v256d"/>
   </union>
   <reg name="v0" bitsize="16384" type="vec64"/>

--- a/gdb/features/ve.c
+++ b/gdb/features/ve.c
@@ -28,9 +28,14 @@ initialize_tdesc_ve (void)
   field_type = tdesc_named_type (feature, "ieee_double");
   tdesc_create_vector (feature, "v256d", field_type, 256);
 
+  field_type = tdesc_named_type (feature, "uint64");
+  tdesc_create_vector (feature, "v256l", field_type, 256);
+
   type = tdesc_create_union (feature, "vec64");
   field_type = tdesc_named_type (feature, "v256d");
   tdesc_add_field (type, "v256_double", field_type);
+  field_type = tdesc_named_type (feature, "v256l");
+  tdesc_add_field (type, "v256_uint64", field_type);
 
   tdesc_create_reg (feature, "usrcc", 0, 1, NULL, 64, "uint64");
   tdesc_create_reg (feature, "pmc0", 1, 1, NULL, 64, "uint64");

--- a/gdb/ve-tdep.c
+++ b/gdb/ve-tdep.c
@@ -1309,6 +1309,9 @@ ve_vec_type (struct gdbarch *gdbarch)
       append_composite_type_field (t, "v256_double",
 				   init_vector_type (bt->builtin_double, 256));
 
+      append_composite_type_field(t, "v256_uint64",
+                                   init_vector_type(bt->builtin_uint64, 256));
+
       TYPE_VECTOR (t) = 1;
       TYPE_NAME (t) = "builtin_type_vec256d";
       tdep->ve_vec_type = t;


### PR DESCRIPTION
This adds support for displaying vector registers as a union type of double-precision floating-point and 64-bit integer, instead of just DP FP.