### PR TITLE
Updated offsets to match ve_elf_fpregset_t, fixing display of VRs/VMs

### DIFF
--- a/gdb/ve-linux-tdep.h
+++ b/gdb/ve-linux-tdep.h
@@ -33,8 +33,8 @@ struct regcache;
 
 #define VEGP_PSW_OFFSET		(0x1000)
 #define VEGP_SCALAR_OFFSET	(0x1400)
-#define VEFP_VMASK_OFFSET	(0x1800)
-#define VEFP_VECTOR_OFFSET	(0x40000)
+#define VEFP_VMASK_OFFSET	(0x0)
+#define VEFP_VECTOR_OFFSET	(0x3E800)
 
 void ve_linux_supply_gregset (const struct regset *regset,
 			      struct regcache *regcache,


### PR DESCRIPTION
This fixes a bug in which VM and VR offsets were being improperly set, resulting in GDB outputting v3 values as v0, v4 as v1, and so on. I updated the offsets to match ve_elf_fpregset_t in arch/ve.h, which appears to resolve the issue; running "p $v0" now appears to properly output the value of v0, rather than the value of v3.